### PR TITLE
1-update syntax julia1.6.2

### DIFF
--- a/test-Pfaffian.jl
+++ b/test-Pfaffian.jl
@@ -1,14 +1,13 @@
 # test against Wimmer's PFAPACK Python implementation: https://michaelwimmer.org/downloads.html
 # (PFAPACK must be installed in the same directory as Pfaffian.jl and this script)
-
+# run the present script in a REPL opened in the same folder as pfapack folder downloaded above
+# note that the Julia Python installation requires scipy to be installed. Do this using Conda.jl before
+# running the test.
 include("Pfaffian.jl")
 
 using PyCall
-@pyimport imp
-path = dirname("pfapack/python/pfaffian.py")
-name = basename("pfapack/python/pfaffian.py")
-(file, filename, data) = imp.find_module("pfaffian", [path]);
-pfaffian = imp.load_module(name, file, filename, data)
+pf = pyimport("pfapack.pfaffian")
+
 
 N = 100
 
@@ -21,7 +20,7 @@ println()
 x = rand(Float64, N)
 
 v, tau, alpha = Householder(x)
-v_w, tau_w, alpha_w = pfaffian[:householder_real](x)
+v_w, tau_w, alpha_w = pf.householder_real(x)
 
 @show maximum(abs, v - v_w)
 @show abs(tau - tau_w)
@@ -29,23 +28,23 @@ v_w, tau_w, alpha_w = pfaffian[:householder_real](x)
 println()
 
 A = rand(Float64, (N, N))
-A = A - A.'
+A = A - A'
 
 T, Q = skew_tridiagonalize(A)
-T_w, Q_w = pfaffian[:skew_tridiagonalize](A)
+T_w, Q_w = pf.skew_tridiagonalize(A)
 
 @show maximum(abs, T - T_w)
 @show maximum(abs, Q - Q_w)
 println()
 
 pf_ltl = Pfaffian_LTL(A)
-pf_ltl_w = pfaffian[:pfaffian](A, method="P")
+pf_ltl_w = pf.pfaffian(A, method="P")
 
 @show abs((pf_ltl - pf_ltl_w)/pf_ltl_w)
 println()
 
 pf_h = Pfaffian_Householder(A)
-pf_h_w = pfaffian[:pfaffian](A, method="H")
+pf_h_w = pf.pfaffian(A, method="H")
 
 @show abs((pf_h - pf_h_w)/pf_h_w)
 println()
@@ -57,31 +56,33 @@ println()
 x = rand(-3:3, N)
 
 v, tau, alpha = Householder(x)
-v_w, tau_w, alpha_w = pfaffian[:householder_real](convert(Vector{Float64}, x))
+v_w, tau_w, alpha_w = pf.householder_real(convert(Vector{Float64}, x))
 
 @show maximum(abs, v - v_w)
 @show abs(tau - tau_w)
 @show abs(alpha - alpha_w)
 println()
 
-A = rand(-3:3, (N, N))
-A = A - A.'
+
+
+A = rand(-10:10, (N, N))
+A = A - A'
 
 T, Q = skew_tridiagonalize(A)
-T_w, Q_w = pfaffian[:skew_tridiagonalize](convert(Matrix{Float64}, A))
+T_w, Q_w = pf.skew_tridiagonalize(convert(Matrix{Float64}, A))
 
 @show maximum(abs, T - T_w)
 @show maximum(abs, Q - Q_w)
 println()
 
 pf_ltl = Pfaffian_LTL(A)
-pf_ltl_w = pfaffian[:pfaffian](A, method="P")
+pf_ltl_w = pf.pfaffian(A, method="P")
 
 @show abs((pf_ltl - pf_ltl_w)/pf_ltl_w)
 println()
 
 pf_h = Pfaffian_Householder(A)
-pf_h_w = pfaffian[:pfaffian](A, method="H")
+pf_h_w = pf.pfaffian(A, method="H")
 
 @show abs((pf_h - pf_h_w)/pf_h_w)
 println()
@@ -90,34 +91,34 @@ println()
 println("Testing complex methods:")
 println()
 
-x = rand(Complex128, N)
+x = rand(ComplexF64, N)
 
 v, tau, alpha = Householder(x)
-v_w, tau_w, alpha_w = pfaffian[:householder_complex](x)
+v_w, tau_w, alpha_w = pf.householder_complex(x)
 
 @show maximum(abs, v - v_w)
 @show abs(tau - tau_w)
 @show abs(alpha - alpha_w)
 println()
 
-A = rand(Complex128, (N, N))
-A = A - A.'
+A = rand(ComplexF64, (N, N))
+A = A - A'
 
 T, Q = skew_tridiagonalize(A)
-T_w, Q_w = pfaffian[:skew_tridiagonalize](A)
+T_w, Q_w = pf.skew_tridiagonalize(A)
 
 @show maximum(abs, T - T_w)
 @show maximum(abs, Q - Q_w)
 println()
 
 pf_ltl = Pfaffian_LTL(A)
-pf_ltl_w = pfaffian[:pfaffian](A, method="P")
+pf_ltl_w = pf.pfaffian(A, method="P")
 
 @show abs((pf_ltl - pf_ltl_w)/pf_ltl_w)
 println()
 
 pf_h = Pfaffian_Householder(A)
-pf_h_w = pfaffian[:pfaffian](A, method="H")
+pf_h_w = pf.pfaffian(A, method="H")
 
 @show abs((pf_h - pf_h_w)/pf_h_w)
 println()


### PR DESCRIPTION
Updated syntax for Julia >1.6.2. Tests were failing with integer valued matrices but the problem is in PFAPACK python implementation. Will open a pull request there too. Tests fail with complex valued matrices because of an assertion error in PFAPACK and I am proceeding with closer investigation